### PR TITLE
Update fusionAuth.js

### DIFF
--- a/src/Stl.Fusion.Blazor/wwwroot/scripts/fusionAuth.js
+++ b/src/Stl.Fusion.Blazor/wwwroot/scripts/fusionAuth.js
@@ -8,8 +8,12 @@ window.FusionAuth = {
     sessionId: "",
     windowTarget: "_blank",
     windowFeatures: "width=600,height=600",
-    signIn: function () {
-        openAuthWindow("signin", "Sign-in");
+    signIn: function (provider) {
+        if (provider === undefined) {
+            openAuthWindow("signin", "Sign-in");
+        } else {
+            openAuthWindow("signin/" + provider, "Sign-in");
+        }
     },
     signOut: function () {
         openAuthWindow("signout", "Sign-out");


### PR DESCRIPTION
Add the ability to provide the login provider when calling signIn. If provider is undefined then default to whatever is configured as the default in dotnet