### PR TITLE
Improvement on Resizing strategy for add range

### DIFF
--- a/src/Stl/AssemblyAttributes.cs
+++ b/src/Stl/AssemblyAttributes.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Stl.Tests")]

--- a/src/Stl/Collections/ArrayBuffer.cs
+++ b/src/Stl/Collections/ArrayBuffer.cs
@@ -3,6 +3,7 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Stl.Internal;
+using Stl.Mathematics;
 
 namespace Stl.Collections
 {
@@ -14,8 +15,8 @@ namespace Stl.Collections
     // ArrayBuffer isn't a ref struct, so you can store it in fields.
     public struct ArrayBuffer<T> : IDisposable
     {
-        public const int MinCapacity = 1;
-        public const int DefaultCapacity = 16;
+        public const int MinCapacity = 8;
+        public const int MaxCapacity = 1 << 30;
         private static readonly ArrayPool<T> Pool = ArrayPool<T>.Shared;
 
         private int _count;
@@ -44,14 +45,13 @@ namespace Stl.Collections
         private ArrayBuffer(bool mustClean, int capacity)
         {
             MustClean = mustClean;
-            if (capacity < MinCapacity)
-                capacity = MinCapacity;
+            capacity = ComputeCapacity(capacity, MinCapacity);
             Buffer = Pool.Rent(capacity);
             _count = 0;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ArrayBuffer<T> Lease(bool mustClean, int capacity = DefaultCapacity)
+        public static ArrayBuffer<T> Lease(bool mustClean, int capacity = MinCapacity)
             => new ArrayBuffer<T>(mustClean, capacity);
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ArrayBuffer<T> LeaseAndSetCount(bool mustClean, int count)
@@ -95,27 +95,25 @@ namespace Stl.Collections
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AddRange(IReadOnlyCollection<T> items)
+        {
+            EnsureCapacity(Count + items.Count);
+            foreach (var item in items)
+                Add(item);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Add(T item)
         {
-            var capacity = Capacity;
-            if (Count >= capacity) {
-                var newCapacity = capacity << 1;
-                if (newCapacity < capacity)
-                    throw Errors.ZListIsTooLong();
-                Resize(newCapacity);
-            }
+            if (Count >= Capacity)
+                EnsureCapacity(Count + 1);
             Buffer[Count++] = item;
         }
 
         public void Insert(int index, T item)
         {
-            var capacity = Capacity;
-            if (Count >= capacity) {
-                var newCapacity = capacity << 1;
-                if (newCapacity < capacity)
-                    throw Errors.ZListIsTooLong();
-                Resize(newCapacity);
-            }
+            if (Count >= Capacity)
+                EnsureCapacity(Count + 1);
             var copyLength = Count - index;
             if (copyLength < 0)
                 throw new ArgumentOutOfRangeException(nameof(index));
@@ -144,26 +142,29 @@ namespace Stl.Collections
             Count = 0;
         }
 
-        public void Resize(int capacity)
-        {
-            if (capacity < MinCapacity)
-                capacity = MinCapacity;
-
-            var span = Buffer.AsSpan();
-            var newLease = Pool.Rent(capacity);
-            if (capacity < Count) {
-                Count = capacity;
-                span = span.Slice(0, capacity);
-            }
-            span.CopyTo(newLease.AsSpan());
-            ChangeLease(newLease);
-        }
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void CopyTo(T[] array, int arrayIndex)
             => Buffer.CopyTo(array.AsSpan().Slice(arrayIndex));
 
+        public void EnsureCapacity(int capacity)
+        {
+            capacity = ComputeCapacity(capacity, Capacity);
+            var newLease = Pool.Rent(capacity);
+            Span.CopyTo(newLease.AsSpan());
+            ChangeLease(newLease);
+        }
+
         // Private methods
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int ComputeCapacity(int requestedCapacity, int minCapacity)
+        {
+            if (requestedCapacity < minCapacity)
+                requestedCapacity = minCapacity;
+            else if (requestedCapacity > MaxCapacity)
+                throw new ArgumentOutOfRangeException(nameof(requestedCapacity));
+            return (int) Bits.GreaterOrEqualPowerOf2((uint) requestedCapacity);
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void ChangeLease(T[] newLease)

--- a/src/Stl/Collections/Collector.cs
+++ b/src/Stl/Collections/Collector.cs
@@ -17,7 +17,7 @@ namespace Stl.Collections
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Collector<T> New(bool mustClean)
-            => new Collector<T>(mustClean, ArrayBuffer<T>.DefaultCapacity);
+            => new Collector<T>(mustClean, ArrayBuffer<T>.MinCapacity);
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Collector<T> New(bool mustClean, int capacity)
             => new Collector<T>(mustClean, capacity);

--- a/src/Stl/Internal/Errors.cs
+++ b/src/Stl/Internal/Errors.cs
@@ -36,8 +36,6 @@ namespace Stl.Internal
         public static Exception UnexpectedMemberType(string memberType) =>
             new InvalidOperationException($"Unexpected member type: {memberType}");
 
-        public static Exception ZListIsTooLong() =>
-            new InvalidOperationException("ZList<T> is too long.");
         public static Exception InvalidListFormat() =>
             new FormatException("Invalid list format.");
 

--- a/src/Stl/InternalsVisibleToFile.cs
+++ b/src/Stl/InternalsVisibleToFile.cs
@@ -1,0 +1,8 @@
+using System;
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Stl.Tests")]
+namespace Stl
+{
+    //Only here for the attribute above. Do not remove.
+}

--- a/src/Stl/InternalsVisibleToFile.cs
+++ b/src/Stl/InternalsVisibleToFile.cs
@@ -1,8 +1,0 @@
-using System;
-using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("Stl.Tests")]
-namespace Stl
-{
-    //Only here for the attribute above. Do not remove.
-}

--- a/tests/Stl.Tests/Collections/ArrayBufferTest.cs
+++ b/tests/Stl.Tests/Collections/ArrayBufferTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using FluentAssertions;
 using Stl.Collections;
 using Xunit;
@@ -51,6 +52,42 @@ namespace Stl.Tests.Collections
                 list[idx] = tmp;
                 buffer.ToArray().Should().Equal(list);
             }
+        }
+
+        [Fact]
+        public void TestEnsureCapacity1()
+        {
+            var minCapacity = ArrayBuffer<int>.MinCapacity;
+            using var b = ArrayBuffer<int>.Lease(true);
+
+            for (var i = 0; i < 3; i++) {
+                var capacity = b.Capacity;
+                capacity.Should().BeGreaterOrEqualTo(minCapacity);
+                var numbers = Enumerable.Range(0, capacity + 1).ToArray();
+                b.AddRange(numbers);
+                b.Capacity.Should().BeGreaterOrEqualTo(capacity << 1);
+            }
+
+            b.Clear();
+            b.Capacity.Should().BeGreaterOrEqualTo(minCapacity);
+
+            // Same test, but with .AddRange(IEnumerable<T>)
+            for (var i = 0; i < 3; i++) {
+                var capacity = b.Capacity;
+                capacity.Should().BeGreaterOrEqualTo(minCapacity);
+                var numbers = Enumerable.Range(0, capacity + 1);
+                b.AddRange(numbers);
+                b.Capacity.Should().BeGreaterOrEqualTo(capacity << 1);
+            }
+        }
+
+        [Fact]
+        public void TestEnsureCapacity2()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => {
+                using var b = ArrayBuffer<int>.Lease(true);
+                b.EnsureCapacity(int.MaxValue);
+            });
         }
     }
 }

--- a/tests/Stl.Tests/Collections/MemoryBufferTest.cs
+++ b/tests/Stl.Tests/Collections/MemoryBufferTest.cs
@@ -17,7 +17,7 @@ namespace Stl.Tests.Collections
             for (var i1 = 0; i1 < 100; i1++) {
                 var list = new List<byte>();
                 for (var l = 0; l < 100; l++) {
-                    list.Add((byte) (_rnd.Next() % 256));
+                    list.Add((byte)(_rnd.Next() % 256));
                     Test(list);
                 }
             }
@@ -76,6 +76,44 @@ namespace Stl.Tests.Collections
             var baseline = Math.Log2(baselineCap);
 
             Assert.Equal(5, verifiedCapacity - baseline);
+        }
+
+        [Fact]
+        public void TestEnsureCapacitySmallerThanCurrent()
+        {
+            var buffer = MemoryBuffer<byte>.Lease(true);
+            buffer.Add(0x01);
+            buffer.Add(0x01);
+            buffer.Add(0x01);
+            buffer.Add(0x01);
+            buffer.Add(0x01);
+
+            var baselineCap = buffer.Capacity;
+            buffer.EnsureCapacity(2);
+
+            Assert.Equal(baselineCap, buffer.Capacity);
+        }
+
+        [Fact]
+        public void TestEnsureCapacityError()
+        {
+            var buffer = MemoryBuffer<byte>.Lease(true);
+
+            try {
+                buffer.EnsureCapacity(-1);
+                Assert.True(false, "Should've thrown exception");
+            }
+            catch (InvalidOperationException) {
+                Assert.True(true);
+            }
+
+            try {
+                buffer.EnsureCapacity(int.MaxValue);
+                Assert.True(false, "Should've thrown exception");
+            }
+            catch (InvalidOperationException) {
+                Assert.True(true);
+            }
         }
 
         [Fact]

--- a/tests/Stl.Tests/Collections/MemoryBufferTest.cs
+++ b/tests/Stl.Tests/Collections/MemoryBufferTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using FluentAssertions;
 using Stl.Collections;
 using Xunit;
@@ -56,6 +57,50 @@ namespace Stl.Tests.Collections
             finally {
                 buffer.Release();
             }
+        }
+
+        [Fact]
+        public void TestEnsureCapacity()
+        {
+            var buffer = MemoryBuffer<byte>.Lease(true);
+            buffer.Add(0x01);
+            buffer.Add(0x01);
+            buffer.Add(0x01);
+            buffer.Add(0x01);
+            buffer.Add(0x01);
+
+            var baselineCap = buffer.Capacity;
+            buffer.EnsureCapacity(baselineCap << 5);//growth exp of 5
+
+            var verifiedCapacity = Math.Log2(buffer.Capacity);
+            var baseline = Math.Log2(baselineCap);
+
+            Assert.Equal(5, verifiedCapacity - baseline);
+        }
+
+        [Fact]
+        public void AddRangeTest()
+        {
+            var buffer = MemoryBuffer<byte>.Lease(true);
+            buffer.Add(0x01);
+            buffer.Add(0x01);
+            buffer.Add(0x01);
+            buffer.Add(0x01);
+            buffer.Add(0x01);
+
+            var baselineCap = buffer.Capacity;
+            var toBeAdded = new List<byte>(1024);// 1024 == 1<<10 and baseline capacity is 1<<3
+
+            for (int i = 0; i < 1024; i++) {
+                toBeAdded.Add((byte)(_rnd.Next() % 256));
+            }
+
+            buffer.AddRange(toBeAdded);
+
+            var verifiedCapacity = Math.Log2(buffer.Capacity);
+            var baseline = Math.Log2(baselineCap);
+
+            Assert.Equal(7, verifiedCapacity - baseline);
         }
     }
 }


### PR DESCRIPTION
This can reduce the amount of resizing operations needed. Further work would be to refactor the `loop->buffer.Add(item)` to a `loop->AddLocal` then `AddRange` to the the buffer.

The Ensure capacity could also be fitted to a non-exponential setting if needed