### PR TITLE
code review updates

### DIFF
--- a/samples/Blazorise/UI/Pages/TodoPage.razor
+++ b/samples/Blazorise/UI/Pages/TodoPage.razor
@@ -7,53 +7,54 @@
 @inject AuthStateProvider AuthStateProvider
 
 @{
+    Debug.WriteLine($"Rendering TodoPage. ConsistencyState: {State.Computed.ConsistencyState}");
+
     var error = State.Error;
     var todos = State.UnsafeValue ?? Array.Empty<Todo>(); // UnsafeValue returns default if there is an Error
 }
 
 <h1>Todo List</h1>
 
-<StatefulComponentState Component="@this"/>
+<ComponentStateLabel StateToWatch="@State" />
+<StatefulComponentState Component="@this" />
 <Text Margin="Margin.Is1.OnY">
-    Updated: <b><MomentsAgoBadge Value="LastStateUpdateTime"/></b>
+    Updated: <b><MomentsAgoBadge Value="LastStateUpdateTime" /></b>
 </Text>
 
 <AuthorizeView>
     <NotAuthorized>
-        <SignInDropdown Why="to use this page"/>
+        <SignInDropdown Why="to use this page" />
     </NotAuthorized>
-    <Authorized><!--
-This comment is here solely to reset the indent in VS / Rider -->
+    <Authorized>
+        <WhenException Exception="error" />
+        <WhenCommandError Exception="CommandRunner.Error" />
+        <Row>
+            <Column ColumnSize="ColumnSize.Is6.OnDesktop.Is12.OnTablet">
+                @foreach (var todo in todos)
+                {
+                    <TodoItem @key="@todo.Id" Value="@todo" />
+                }
 
-<WhenException Exception="error"/>
-<WhenCommandError Exception="CommandRunner.Error"/>
+                @if (HasMore)
+                {
+                    <Button Clicked="_ => LoadMore()" Color="Color.Primary" Margin="Margin.Is3.OnY">
+                        Load more <Blazorise.Icon Name="FontAwesomeIcons.AngleDoubleDown" />
+                    </Button>
+                }
 
-<Row><Column ColumnSize="ColumnSize.Is6.OnDesktop.Is12.OnTablet">
-    @foreach(var todo in todos) {
-        <TodoItem @key="@todo.Id" Value="@todo" />
-    }
-
-    @if (HasMore) {
-        <Button Clicked="_ => LoadMore()" Color="Color.Primary" Margin="Margin.Is3.OnY">
-            Load more <Blazorise.Icon Name="FontAwesomeIcons.AngleDoubleDown"/>
-        </Button>
-    }
-
-    <Form @onsubmit="_ => Create()" Margin="Margin.Is3.OnY" >
-        <Addons>
-            <Addon AddonType="AddonType.Start">
-                <Button Type="@ButtonType.Submit" Color="Color.Primary">
-                    <Blazorise.Icon Name="@FontAwesomeIcons.PlusSquare"/>
-                </Button>
-            </Addon>
-            <input @bind="NewTodoTitle" @bind:event="onchange" class="form-control"/>
-        </Addons>
-    </Form>
-
-</Column></Row>
-
-<!--
- --></Authorized>
+                <Form @onsubmit="_ => Create()" Margin="Margin.Is3.OnY">
+                    <Addons>
+                        <Addon AddonType="AddonType.Start">
+                            <Button Type="@ButtonType.Submit" Color="Color.Primary">
+                                <Blazorise.Icon Name="@FontAwesomeIcons.PlusSquare" />
+                            </Button>
+                        </Addon>
+                        <input @bind="NewTodoTitle" @bind:event="onchange" class="form-control" />
+                    </Addons>
+                </Form>
+            </Column>
+        </Row>
+    </Authorized>
 </AuthorizeView>
 
 @code {
@@ -69,7 +70,6 @@ This comment is here solely to reset the indent in VS / Rider -->
     protected override void OnInitialized()
     {
         CommandRunner.Component = this;
-        StateHasChangedTriggers = StateEventKind.All;
         base.OnInitialized();
     }
 

--- a/samples/Blazorise/UI/Shared/ComponentStateLabel.razor
+++ b/samples/Blazorise/UI/Shared/ComponentStateLabel.razor
@@ -1,0 +1,55 @@
+@using Stl.Fusion
+@using Stl.Async; 
+@using System.Threading
+@using Templates.Blazor2.Abstractions
+@implements IDisposable
+@inherits ComponentBase
+@*
+    ComponentStateLabel:
+    - shows the current state of the Computed passed in as 'StateToWatch'. States are Invalidated/Updating/Updated.
+    - renders on state change without a rerender of the parent component
+*@
+
+<Text Margin="Margin.Is1.OnY">
+    <span>Component state: </span>
+    @if (_stateEventKind != StateEventKind.Updated)
+    {
+        <div class="spinner-border spinner-border-sm text-primary" role="status"></div>
+    }
+    else
+    {
+        <span class="oi oi-check" aria-hidden="true"></span>
+    }
+    <b>@_stateEventKind</b>
+</Text>
+
+@code {
+    [Parameter]
+    public IState? StateToWatch { get; set; } = null;
+
+    private StateEventKind _stateEventKind = StateEventKind.Updated;
+    private Action<IState, StateEventKind>? _handleStateChanged;
+
+    protected override void OnParametersSet()
+    {
+        base.OnParametersSet();
+
+        _handleStateChanged = (state, stateEventKind) =>
+        {
+            if (_stateEventKind != stateEventKind)
+            {
+                _stateEventKind = stateEventKind;
+                Debug.WriteLine($"ComponentStateLabel state changed: {stateEventKind} {state.Computed.ConsistencyState}");
+                this.StateHasChangedAsync().Ignore();
+            }
+        };
+
+        StateToWatch?.AddEventHandler(StateEventKind.All, _handleStateChanged);
+    }
+
+    public virtual void Dispose()
+    {
+        if (_handleStateChanged != null)
+            StateToWatch?.RemoveEventHandler(StateEventKind.All, _handleStateChanged);
+    }
+}

--- a/samples/Blazorise/UI/Shared/ComponentStateLabel.razor
+++ b/samples/Blazorise/UI/Shared/ComponentStateLabel.razor
@@ -40,6 +40,9 @@
             {
                 _stateEventKind = stateEventKind;
                 Debug.WriteLine($"ComponentStateLabel state changed: {stateEventKind} {state.Computed.ConsistencyState}");
+                // We don't call StateHasChanged() because this event handler is called from a thread-pool thread
+                // and StateHasChanged() sometimes synchronously re-renders the component. Instead we call 
+                // StateHasChangedAsync which queues a call to StateHasChanged() on the Blazor UI thread for this component
                 this.StateHasChangedAsync().Ignore();
             }
         };

--- a/src/Stl.Fusion.Blazor/StatefulComponentBase.cs
+++ b/src/Stl.Fusion.Blazor/StatefulComponentBase.cs
@@ -42,6 +42,8 @@ namespace Stl.Fusion.Blazor
         Task IHandleEvent.HandleEventAsync(EventCallbackWorkItem callback, object? arg)
         {
             // This code is copied from ComponentBase
+            // Remove this implementation when 'MustTriggerStateHasChangedOnEvent' becomes a regular Blazor feature 
+            // https://github.com/dotnet/aspnetcore/issues/18919#issuecomment-803005864
             var task = callback.InvokeAsync(arg);
             var shouldAwaitTask =
                 task.Status != TaskStatus.RanToCompletion &&


### PR DESCRIPTION
> please validate the part about disposal

I personally would opt not to reflect into private fields to prevent this exception. The workaround to just catch and ignore the objectdisposed exception does the job as well and saves you piece of smart but horrible code that may break on future blazor updates. I added some comments to ComponentEx to explain to future code readers why this code exists in this manner. Also, the method StateHasChangedAsync had an optional argument to run synchronously, I did not see the point of that as you should always want to switch to the blazor UI context if you call this method -- its for callers that call into the component from threads that are not participating the event lifecyle/flow of the component. If you know that you are already in the right context you should just call StateHasChanged() in my opinion.

- VS.NET does not ignore the indent after remarks (as opposed to Rider) so my changes did a regular format, and I did remove the comment to prevent future merge conflicts on that.

- I added Debug.WriteLine($"Rendering TodoPage_.. ") to the todopage. There were many extra renders because of StateHasChangedTriggers = StateEventKind.All; still being there. I removed it, and it saves renderers on state invalidation, it just renders on a new updated state.

- because of the removal of StateHasChangedTriggers; the StatefulComponentState no longer works, so I put in ComponentStateLabel 
