### PR TITLE
Simplify CliWrap usage

### DIFF
--- a/build/CliWrapCommandExtensions.cs
+++ b/build/CliWrapCommandExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using CliWrap;
+using CliWrap.Builders;
 
 namespace Build
 {
@@ -10,6 +11,10 @@ namespace Build
         internal static Stream _stderr = Console.OpenStandardError();
 
         internal static Command ToConsole(this Command command) => command | (_stdout, _stderr);
+
+        internal static ArgumentsBuilder AddOption(this ArgumentsBuilder args, string name, string value) =>
+            !string.IsNullOrEmpty(value)
+                ? args.Add(name).Add(value)
+                : args;
     }
 }
-

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -147,7 +147,7 @@ namespace Build
                     .Select(PathString.New)
                     .ToArray();
                 foreach (var nupkgPath in nupkgPaths) {
-                    await Cli.Wrap(dotnetExePath).WithArguments(new[] {
+                    await Cli.Wrap(dotnetExePath).WithArguments(new string[] {
                             "nuget",
                             "push",
                             nupkgPath,


### PR DESCRIPTION
Hi 👋🏻 
Was browsing projects that use CliWrap and decided to make a small refactor 🙂 
Tip: you can use the sequence or builder overload of `WithArguments(...)` to take care of escaping automatically for you. With the arguments overload you can even create your own extension methods to do fun things with!

Oh and instead of `.Task.ConfigureAwait(false)` you can just do `.ConfigureAwait(false)` as well.