### PR TITLE
Add logging to JsonifyErrors

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -42,6 +42,8 @@
   </PropertyGroup>
 
   <ItemGroup Label="Package Versions">
+    <PackageReference Update="ILogger.Moq" Version="1.1.10" />
+    <PackageReference Update="AutoFixture.AutoMoq" Version="4.17.0" />
     <PackageReference Update="AspNet.Security.OAuth.GitHub" Version="6.0.4" />
     <PackageReference Update="Blazorise" Version="$(BlazoriseVersion)" />
     <PackageReference Update="Blazorise.Bootstrap" Version="$(BlazoriseVersion)" />

--- a/tests/Stl.Fusion.Tests/BaseFixture.cs
+++ b/tests/Stl.Fusion.Tests/BaseFixture.cs
@@ -1,0 +1,17 @@
+﻿using AutoFixture;
+using AutoFixture.AutoMoq;
+
+namespace Stl.Fusion.Tests;
+
+public abstract class BaseFixture<T>
+{
+    protected IFixture Fixture { get; }
+
+    protected BaseFixture()
+    {
+        Fixture = new Fixture()
+            .Customize(new AutoMoqCustomization {ConfigureMembers = true});
+    }
+
+    public T Create() => Fixture.Create<T>();
+}

--- a/tests/Stl.Fusion.Tests/Server/ExceptionContextFixture.cs
+++ b/tests/Stl.Fusion.Tests/Server/ExceptionContextFixture.cs
@@ -1,0 +1,87 @@
+﻿#if NETFRAMEWORK
+using System.Web.Http.Filters;
+using System.Web.Http.Controllers;
+using System.Web.Http;
+using System.Web.Http.Dependencies;
+#else
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+#endif
+
+using Moq;
+using AutoFixture;
+using Stl.Fusion.Server;
+
+namespace Stl.Fusion.Tests.Server;
+
+public class ExceptionContextFixture : BaseFixture<
+#if NETFRAMEWORK
+    HttpActionExecutedContext
+#else
+    ExceptionContext
+#endif
+>
+{
+    private Mock<ILogger<JsonifyErrorsAttribute>> _loggerMock = new();
+    private Mock<IErrorRewriter> _errorRewritterMock = new();
+#if NETFRAMEWORK
+    private Mock<IDependencyResolver> _serviceProviderMock = new();
+#else
+    private Mock<IServiceProvider> _serviceProviderMock = new();
+    private Mock<IActionResultExecutor<ContentResult>> _actionResultExecutorMock = new();
+#endif
+
+    public ExceptionContextFixture()
+    {
+        _errorRewritterMock.Setup(x =>
+                x.Rewrite(It.IsAny<object>(), It.IsAny<Exception>(), It.IsAny<bool>()))
+            .Returns((object _, Exception x, bool _) => x);
+
+        _serviceProviderMock
+            .Setup(x => x.GetService(typeof(IErrorRewriter)))
+            .Returns(_errorRewritterMock.Object);
+
+        _serviceProviderMock
+            .Setup(x => x.GetService(typeof(ILogger<JsonifyErrorsAttribute>)))
+            .Returns(_loggerMock.Object);
+
+        Fixture.Register(() => _serviceProviderMock);
+
+#if NETFRAMEWORK
+        Fixture.Customize<HttpActionExecutedContext>(x => 
+            x.Without(x => x.Response));
+        Fixture.Register(() =>
+            new HttpActionContext {
+                ControllerContext = new HttpControllerContext {
+                    Request = new HttpRequestMessage(),
+                    Configuration = Fixture.Create<HttpConfiguration>(),
+                },
+            });
+#else
+        Fixture.Customize<BindingInfo>(x => x.OmitAutoProperties());
+
+        _serviceProviderMock
+            .Setup(x => x.GetService(typeof(IActionResultExecutor<ContentResult>)))
+            .Returns(_actionResultExecutorMock.Object);
+#endif
+    }
+
+    public ExceptionContextFixture WithException(string message)
+    {
+        Fixture.Register(() => new Exception(message));
+        return this;
+    }
+
+    public void VerifyLogError(string message)
+    {
+        _loggerMock.VerifyLog(logger => logger.LogError(It.IsAny<Exception>(), message));
+    }
+
+    public void VerifyErrorRewrite(bool isExpected)
+    {
+        _errorRewritterMock.Verify(x => x.Rewrite(It.IsAny<object>(), It.IsAny<Exception>(), It.IsAny<bool>()),
+            Times.Exactly(isExpected ? 1 : 0));
+    }
+}

--- a/tests/Stl.Fusion.Tests/Server/JsonifyErrorsAttributeFixture.cs
+++ b/tests/Stl.Fusion.Tests/Server/JsonifyErrorsAttributeFixture.cs
@@ -1,0 +1,41 @@
+﻿#if NETFRAMEWORK
+using System.Web.Http.Filters;
+#else
+using Microsoft.AspNetCore.Mvc.Filters;
+#endif
+
+using AutoFixture;
+using Stl.Fusion.Server;
+
+namespace Stl.Fusion.Tests.Server;
+
+public class JsonifyErrorsAttributeFixture : BaseFixture<JsonifyErrorsAttribute>
+{
+    private bool _rewriteErrors = true;
+
+    public JsonifyErrorsAttributeFixture()
+    {
+        Fixture.Register(() => new JsonifyErrorsAttribute {RewriteErrors = _rewriteErrors});
+    }
+
+    public JsonifyErrorsAttributeFixture WithRewriteErrors(bool value)
+    {
+        _rewriteErrors = value;
+        return this;
+    }
+
+    public Task OnExceptionAsync(
+#if NETFRAMEWORK
+        HttpActionExecutedContext
+#else
+        ExceptionContext
+#endif
+            context)
+    {
+#if NETFRAMEWORK
+        return Create().OnExceptionAsync(context, CancellationToken.None);
+#else
+        return Create().OnExceptionAsync(context);
+#endif
+    }
+}

--- a/tests/Stl.Fusion.Tests/Server/JsonifyErrorsAttributeTests.cs
+++ b/tests/Stl.Fusion.Tests/Server/JsonifyErrorsAttributeTests.cs
@@ -1,0 +1,31 @@
+﻿namespace Stl.Fusion.Tests.Server;
+
+public class JsonifyErrorsAttributeTests
+{
+    [Fact]
+    public void OnException_Should_Log()
+    {
+        var expectedMessage = "A";
+        var exceptionContextFixture = new ExceptionContextFixture().WithException(expectedMessage);
+        var exceptionContext = exceptionContextFixture.Create();
+        var jsonifyErrorsFixture = new JsonifyErrorsAttributeFixture();
+
+        jsonifyErrorsFixture.OnExceptionAsync(exceptionContext);
+
+        exceptionContextFixture.VerifyLogError(expectedMessage);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void OnException_Should_RewriteErrorsIfSet(bool rewriteErrors)
+    {
+        var exceptionContextFixture = new ExceptionContextFixture();
+        var exceptionContext = exceptionContextFixture.Create();
+        var jsonifyErrorsFixture = new JsonifyErrorsAttributeFixture().WithRewriteErrors(rewriteErrors);
+
+        jsonifyErrorsFixture.OnExceptionAsync(exceptionContext);
+
+        exceptionContextFixture.VerifyErrorRewrite(rewriteErrors);
+    }
+}

--- a/tests/Stl.Fusion.Tests/Stl.Fusion.Tests.csproj
+++ b/tests/Stl.Fusion.Tests/Stl.Fusion.Tests.csproj
@@ -12,7 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="ILogger.Moq" />
     <PackageReference Include="System.Net.WebSockets.Client" />
+    <PackageReference Include="AutoFixture.AutoMoq" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('net6'))">
     <PackageReference Include="EFCore.CheckConstraints" />
@@ -29,7 +31,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" VersionOverride="$(EntityFrameworkCoreVersion5)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" VersionOverride="$(EntityFrameworkCoreVersion5)" />
     <PackageReference Include="MySqlConnector" VersionOverride="$(MySqlVersion5)" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" VersionOverride="$(EntityFrameworkCoreMySqlVersion5)"/>
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" VersionOverride="$(EntityFrameworkCoreMySqlVersion5)" />
     <PackageReference Include="System.Drawing.Common" VersionOverride="$(SystemDrawingVersion5)" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
@@ -37,7 +39,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" VersionOverride="$(EntityFrameworkCoreVersion3)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" VersionOverride="$(EntityFrameworkCoreVersion3)" />
     <PackageReference Include="MySqlConnector" VersionOverride="$(MySqlVersion3)" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" VersionOverride="$(EntityFrameworkCoreMySqlVersion3)"/>
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" VersionOverride="$(EntityFrameworkCoreMySqlVersion3)" />
     <PackageReference Include="System.Drawing.Common" VersionOverride="$(SystemDrawingVersion5)" />
   </ItemGroup>
 


### PR DESCRIPTION
Before, calling a service would return errors as a Json but nothing was logged. 
With this pull request, we can view the errors in an aggregation platform like Sentry.io.

- The code has been modified for .Net Core and .Net Framework.
- Tests have also been written using the Fixture parttern.


NOTE that my tests all passed for all platforms but I had errors with other tests.
```
It was not possible to connect to the redis server(s). Error connecting right now. To allow this multipl...
```

