### PR TITLE
feat: add hint for Stl.Generators package to the NoProxyType exception

### DIFF
--- a/src/Stl.Interception/Internal/Errors.cs
+++ b/src/Stl.Interception/Internal/Errors.cs
@@ -3,7 +3,7 @@ namespace Stl.Interception.Internal;
 public static class Errors
 {
     public static Exception NoProxyType(Type type)
-        => new InvalidOperationException($"Type '{type.GetName()}' doesn't have a proxy type generated for it.");
+        => new InvalidOperationException($"Type '{type.GetName()}' doesn't have a proxy type generated for it. Please verify that the package 'Stl.Generators' is installed.");
 
     public static Exception InvalidProxyType(Type? type, Type expectedType)
         => new InvalidOperationException(


### PR DESCRIPTION
I just ran into this exception and it wasn't obvious to me that the underlying issue was the missing `Stl.Generators` package. By providing this hint, users might have a better experience in the future.