### PR TITLE
memory leak fix

### DIFF
--- a/src/Stl.Fusion.Server.NetFx/DefaultDependencyResolver.cs
+++ b/src/Stl.Fusion.Server.NetFx/DefaultDependencyResolver.cs
@@ -4,11 +4,18 @@ namespace Stl.Fusion.Server;
 
 public class DefaultDependencyResolver : IDependencyResolver
 {
-    private IServiceProvider serviceProvider;
+    private readonly IServiceProvider serviceProvider;
+    private readonly IServiceScope? scope;
 
     public DefaultDependencyResolver(IServiceProvider serviceProvider)
     {
         this.serviceProvider = serviceProvider;
+    }
+
+    private DefaultDependencyResolver(IServiceScope scope)
+    {
+        this.serviceProvider = scope.ServiceProvider;
+        this.scope = scope;
     }
 
     public object GetService(Type serviceType)
@@ -25,10 +32,14 @@ public class DefaultDependencyResolver : IDependencyResolver
 
     public void Dispose()
     {
+        if (serviceProvider is IDisposable disposable)
+            disposable.Dispose();
+
+        scope?.Dispose();
     }
 
     public IDependencyScope BeginScope()
     {
-        return this;
+        return new DefaultDependencyResolver(serviceProvider.CreateScope());
     }
 }


### PR DESCRIPTION
`DefaultDependencyResolver` didn't implement `BeginScope` method (in fact) - it just returns its own reference.
This makes all request-scoped services to be instantiated in root scope - and never disposed and removed:

![image](https://user-images.githubusercontent.com/21177786/230623576-50ab652a-97e8-4df2-b5aa-cc9ae82c1f4b.png)
