### PR TITLE
feat: reduce concurrency locks for sessions

### DIFF
--- a/src/Stl.Fusion.Ext.Services/Authentication/Services/DbAuthService.Backend.cs
+++ b/src/Stl.Fusion.Ext.Services/Authentication/Services/DbAuthService.Backend.cs
@@ -101,7 +101,7 @@ public partial class DbAuthService<TDbContext, TDbSessionInfo, TDbUser, TDbUserI
         var dbContext = await CreateCommandDbContext(tenant, cancellationToken).ConfigureAwait(false);
         await using var _1 = dbContext.ConfigureAwait(false);
 
-        var dbSessionInfo = await Sessions.Get(dbContext, session.Id, true, cancellationToken).ConfigureAwait(false);
+        var dbSessionInfo = await Sessions.Get(dbContext, session.Id, false, cancellationToken).ConfigureAwait(false);
         var isNew = dbSessionInfo == null;
         var now = Clocks.SystemClock.Now;
         var sessionInfo = SessionConverter.ToModel(dbSessionInfo)
@@ -152,7 +152,7 @@ public partial class DbAuthService<TDbContext, TDbSessionInfo, TDbUser, TDbUserI
         var dbContext = await CreateCommandDbContext(tenant, cancellationToken).ConfigureAwait(false);
         await using var _1 = dbContext.ConfigureAwait(false);
 
-        var dbSessionInfo = await Sessions.Get(dbContext, session.Id, true, cancellationToken).ConfigureAwait(false);
+        var dbSessionInfo = await Sessions.Get(dbContext, session.Id, false, cancellationToken).ConfigureAwait(false);
         var sessionInfo = SessionConverter.ToModel(dbSessionInfo);
         if (sessionInfo == null)
             throw new KeyNotFoundException();

--- a/src/Stl.Fusion.Ext.Services/Authentication/Services/DbSessionInfoRepo.cs
+++ b/src/Stl.Fusion.Ext.Services/Authentication/Services/DbSessionInfoRepo.cs
@@ -75,11 +75,11 @@ public class DbSessionInfoRepo<TDbContext, TDbSessionInfo, TDbUserId> : DbServic
     public async Task<TDbSessionInfo> Upsert(
         TDbContext dbContext, string sessionId, SessionInfo sessionInfo, CancellationToken cancellationToken = default)
     {
-        var dbSessionInfo = await dbContext.Set<TDbSessionInfo>().ForUpdate()
-            .SingleOrDefaultAsync(s => s.Id == sessionId, cancellationToken)
+        var dbSessionInfo = await dbContext.Set<TDbSessionInfo>().ForNoKeyUpdate()
+            .FirstOrDefaultAsync(s => s.Id == sessionId, cancellationToken)
             .ConfigureAwait(false);
         var isDbSessionInfoFound = dbSessionInfo != null;
-        dbSessionInfo ??= new TDbSessionInfo() {
+        dbSessionInfo ??= new() {
             Id = sessionId,
             CreatedAt = sessionInfo.CreatedAt,
         };
@@ -121,10 +121,10 @@ public class DbSessionInfoRepo<TDbContext, TDbSessionInfo, TDbUserId> : DbServic
         TDbContext dbContext, string sessionId, bool forUpdate, CancellationToken cancellationToken = default)
     {
         var dbSessionInfos = forUpdate
-            ? dbContext.Set<TDbSessionInfo>().ForUpdate()
-            : dbContext.Set<TDbSessionInfo>();
+            ? dbContext.Set<TDbSessionInfo>().ForNoKeyUpdate()
+            : dbContext.Set<TDbSessionInfo>().ForKeyShare();
         return await dbSessionInfos
-            .SingleOrDefaultAsync(s => s.Id == sessionId, cancellationToken)
+            .FirstOrDefaultAsync(s => s.Id == sessionId, cancellationToken)
             .ConfigureAwait(false);
     }
 


### PR DESCRIPTION
- `SELECT TOP 1` instead of `TOP 2`
- Compatible locks for read\update according to https://www.postgresql.org/docs/15/explicit-locking.html#LOCKING-ROWS
