### PR TITLE
Add TypeFactory

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,7 @@ indent_size = 2
 [*.md]
 trim_trailing_whitespace = false
 
-[*.cs, *.js, *.tsx]
+[*.{cs,js,tsx}]
 indent_size = 4
 indent_style = space
 trim_trailing_whitespace = true

--- a/src/Stl.Interception/Interceptors/TypeFactoryInterceptor.cs
+++ b/src/Stl.Interception/Interceptors/TypeFactoryInterceptor.cs
@@ -1,0 +1,34 @@
+using StlErrors = Stl.Internal.Errors;
+
+namespace Stl.Interception.Interceptors;
+
+public class TypeFactoryInterceptor(IServiceProvider services) : Interceptor
+{
+    private static readonly Func<MethodInfo, ObjectFactory> CreateFactoryMethod = CreateFactory;
+    // Factories are statically cached - Interceptor defines IServiceProvider scope
+    private static readonly ConcurrentDictionary<MethodInfo, ObjectFactory> FactoriesCache = new();
+    private readonly IServiceProvider _services = services;
+
+    public override void Intercept(Invocation invocation)
+        => throw StlErrors.NotSupported("TypeFactory doesn't support void methods.");
+
+    public override TResult Intercept<TResult>(Invocation invocation)
+    {
+        ObjectFactory m = FactoriesCache.GetOrAdd(invocation.Method, CreateFactoryMethod);
+        // Probably not changeable.
+        // ObjectFactory is `object ObjectFactory(IServiceProvider, object[] args)`.
+        return (TResult)m(_services, invocation.Arguments.ToArray());
+    }
+
+    private static ObjectFactory CreateFactory(MethodInfo method)
+    {
+        var parameters = method.GetParameters();
+        var parameterTypes = new Type[parameters.Length];
+        for (int i = 0; i < parameters.Length; i++)
+        {
+            parameterTypes[i] = parameters[i].ParameterType;
+        } // bench: This is faster than any other option (Linq).
+
+        return ActivatorUtilities.CreateFactory(method.ReturnType, parameterTypes);
+    }
+}

--- a/src/Stl.Interception/ServiceCollectionTypeFactoryExt.cs
+++ b/src/Stl.Interception/ServiceCollectionTypeFactoryExt.cs
@@ -1,0 +1,69 @@
+using Stl.Interception.Interceptors;
+
+namespace Stl.Interception;
+
+public static class ServiceCollectionTypeFactoryExt
+{
+    public static IServiceCollection AddScopedTypeFactory<TFactory>(this IServiceCollection services)
+        where TFactory : class, IRequiresAsyncProxy
+    {
+        return AddTypeFactory<TFactory>(services, ServiceLifetime.Scoped);
+    }
+
+    public static IServiceCollection AddSingletonTypeFactory<TFactory>(this IServiceCollection services)
+        where TFactory : class, IRequiresAsyncProxy
+    {
+        return AddTypeFactory<TFactory>(services, ServiceLifetime.Singleton);
+    }
+
+    public static IServiceCollection AddTypeFactory<TFactory>(this IServiceCollection services, ServiceLifetime lifetime)
+        where TFactory : class, IRequiresAsyncProxy
+    {
+        return AddTypeFactory<TFactory, TypeFactoryInterceptor>(services, lifetime);
+    }
+
+    public static IServiceCollection AddTypeFactory<TFactory, TInterceptor>(this IServiceCollection services, ServiceLifetime lifetime)
+        where TFactory : class, IRequiresAsyncProxy
+        where TInterceptor : Interceptor
+    {
+        return AddTypeFactory(services, typeof(TFactory), typeof(TInterceptor), lifetime);
+    }
+
+    public static IServiceCollection AddTypeFactory(this IServiceCollection services, Type factoryType, Type interceptorType, ServiceLifetime lifetime)
+    {
+        // All implementations converge here.
+        // Single source of Proxies.GetProxyType if not specified by any of the TProxy-variants.
+        return AddTypeFactory(services, factoryType, Proxies.GetProxyType(factoryType), interceptorType, lifetime);
+    }
+
+    public static IServiceCollection AddTypeFactory<TFactory, TProxy, TInterceptor>(this IServiceCollection services, ServiceLifetime lifetime)
+        where TFactory : class, IRequiresAsyncProxy
+        where TProxy : TFactory
+        where TInterceptor : Interceptor
+    {
+        return AddTypeFactory(services, typeof(TFactory), typeof(TProxy), typeof(TInterceptor), lifetime);
+    }
+
+    public static IServiceCollection AddTypeFactory(
+        this IServiceCollection services,
+        Type factoryType,
+        Type proxyType,
+        Type interceptorType,
+        ServiceLifetime lifetime)
+    {
+        services.Add(new ServiceDescriptor(factoryType, services =>
+        { // no way to circumvent closure here
+            var interceptor = (Interceptor)services.GetOrActivate(interceptorType);
+            var proxy = (IProxy)services.GetOrActivate(proxyType);
+            interceptor.BindTo(proxy);
+            return proxy;
+        }, lifetime));
+        return services;
+    }
+
+    public static IServiceCollection UseTypeFactories(this IServiceCollection services)
+    {
+        services.AddScoped<TypeFactoryInterceptor>();
+        return services;
+    }
+}

--- a/src/Stl.Interception/ServiceCollectionTypeFactoryInterceptorExt.cs
+++ b/src/Stl.Interception/ServiceCollectionTypeFactoryInterceptorExt.cs
@@ -1,0 +1,18 @@
+namespace Stl.Interception;
+
+public static class ServiceCollectionTypeFactoryInterceptorExt
+{
+    public static IServiceCollection AddScopedTypeFactory<TFactory, TInterceptor>(this IServiceCollection services)
+        where TFactory : class, IRequiresAsyncProxy
+        where TInterceptor : Interceptor
+    {
+        return services.AddTypeFactory<TFactory, TInterceptor>(ServiceLifetime.Scoped);
+    }
+
+    public static IServiceCollection AddSingletonTypeFactory<TFactory, TInterceptor>(this IServiceCollection services)
+        where TFactory : class, IRequiresAsyncProxy
+        where TInterceptor : Interceptor
+    {
+        return services.AddTypeFactory<TFactory, TInterceptor>(ServiceLifetime.Singleton);
+    }
+}

--- a/src/Stl.Interception/ServiceCollectionTypeFactoryProxyExt.cs
+++ b/src/Stl.Interception/ServiceCollectionTypeFactoryProxyExt.cs
@@ -1,0 +1,27 @@
+using Stl.Interception.Interceptors;
+
+namespace Stl.Interception;
+
+public static class ServiceCollectionTypeFactoryProxyExt
+{
+    public static IServiceCollection AddScopedTypeFactory<TFactory, TProxy>(this IServiceCollection services)
+        where TFactory : class, IRequiresAsyncProxy
+        where TProxy : TFactory
+    {
+        return AddTypeFactory<TFactory, TProxy>(services, ServiceLifetime.Scoped);
+    }
+
+    public static IServiceCollection AddSingletonTypeFactory<TFactory, TProxy>(this IServiceCollection services)
+        where TFactory : class, IRequiresAsyncProxy
+        where TProxy : TFactory
+    {
+        return AddTypeFactory<TFactory, TProxy>(services, ServiceLifetime.Singleton);
+    }
+
+    public static IServiceCollection AddTypeFactory<TFactory, TProxy>(this IServiceCollection services, ServiceLifetime lifetime)
+        where TFactory : class, IRequiresAsyncProxy
+        where TProxy : TFactory
+    {
+        return services.AddTypeFactory<TFactory, TProxy, TypeFactoryInterceptor>(lifetime);
+    }
+}

--- a/tests/Stl.Tests/Interception/TypeFactoryTest.cs
+++ b/tests/Stl.Tests/Interception/TypeFactoryTest.cs
@@ -1,0 +1,32 @@
+using Stl.Interception;
+
+namespace Stl.Tests.Interception;
+
+public class TypeFactoryTest
+{
+    [Fact]
+    public void TestMethodBasedFactory()
+    {
+        ServiceCollection services = new();
+        services.UseTypeFactories();
+        services.AddSingletonTypeFactory<ITestFactory>();
+        var provider = services.BuildServiceProvider();
+        var factory = provider.GetRequiredService<ITestFactory>();
+        var instance = factory.Create(7);
+        instance.Should().BeOfType(typeof(TestFactoryClass));
+        instance.Arg1.Should().Be(7);
+        instance.Services.Should().NotBeNull();
+    }
+}
+
+public class TestFactoryClass(int Arg1, IServiceProvider Services)
+{
+    public int Arg1 { get; } = Arg1;
+
+    public IServiceProvider Services { get; } = Services;
+}
+
+public interface ITestFactory : IRequiresFullProxy
+{
+    TestFactoryClass Create(int ctorArg0);
+}


### PR DESCRIPTION
Full interface for TypeFactory:

```
// Convention Scoped
AddScopedTypeFactory<TFactory>()
AddScopedTypeFactory<TFactory, TProxy>()
AddScopedTypeFactory<TFactory, TInterceptor>()

// Convention Singleton
AddSingletonTypeFactory<TFactory>()
AddSingletonTypeFactory<TFactory, TProxy>()
AddSingletonTypeFactory<TFactory, TInterceptor>()

AddTypeFactory<TFactory>()
AddTypeFactory<TFactory, TProxy>()
AddTypeFactory<TFactory, TInterceptor>()
AddTypeFactory<TFactory, TProxy, TInterceptor>()
AddTypeFactory(Type, Type)
AddTypeFactory(Type, Type, Type)

UseTypeFactories()
```

Remarks:
- All methods are extensions and comply to `IServiceCollection(IServiceCollection, …, ServiceLifetime)`
  By convention (`AddScoped`, `AddSingleton`) or by parameter)
- Whenever `TFactory` is mentioned, assume `where TFactory : class, IRequiresAsyncProxy`
- Whenever `TProxy` is mentioned, assume `where TProxy : TFactory`
- Whenever `TInterceptor` is mentioned, assume `where TInterceptor : Interceptor`

Resolves #649 